### PR TITLE
Lucashamaguchi/bug/none attributes

### DIFF
--- a/firestore/db/connection.py
+++ b/firestore/db/connection.py
@@ -42,6 +42,16 @@ class ResultSet(object):
     def __len__(self):
         return len(self.__data__)
 
+    def __next__(self):
+        _next = self.first()
+        if _next:
+            return _next
+        else:
+            raise StopIteration
+    
+    def __iter__(self):
+        return self
+
 
 class Connection(object):
     """

--- a/firestore/db/connection.py
+++ b/firestore/db/connection.py
@@ -106,7 +106,7 @@ class Connection(object):
 
         query = query.limit(limit)
 
-        rs = ResultSet([coll_cls(doc.to_dict()) for doc in query.stream()])
+        rs = ResultSet([coll_cls(**doc.to_dict()) for doc in query.stream()])
         return rs
 
     def get(self, cls, uid):


### PR DESCRIPTION
#### Issue description
When querying any collection, all the attributes return None

#### Steps to reproduce the issue
I am running on Python 3.7, MacOs Mojave
1.  Install the project
2. Run the following script
```
from firestore import Collection, String
from firestore.db import Connection


CREDENTIALS_PATH = 'path/to/credentials.json'

conn = Connection(CREDENTIALS_PATH)


class User(Collection):
    __collection__ = 'user'

    first_name = String(required=True)
    last_name = String()


user = User(**{
    'first_name': 'user',
    'last_name': 'test'
})
user.save()

users = User.find()
user = users.next()
print(user.first_name)

>> None
```


#### What's the expected result?

- user.first_name return "user"


#### What's the actual result?

- user.first_name returns None
